### PR TITLE
remove eps(T) from fraction pol calculations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolarizedTypes"
 uuid = "d3c5d4cd-a8ee-40d6-aac7-e34df5a20044"
 authors = ["Paul Tiede <ptiede91@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.2.0-DEV"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -80,7 +80,7 @@ Computes the complex fractional linear polarization of the complex or visibility
 Note that this function can also be called used [`mbreve`](@ref) or [`mpol`](@ref).
 """
 m̆(m::StokesParams) = mpol(m)
-
+@deprecate m̆(m::StokesParams) mpol(m)
 
 """
     $(SIGNATURES)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -63,8 +63,7 @@ end
 
 Returns the (Q/I, U/I, V/I) fractional polarization vector as a 3-element static vector.
 """
-fracpolarization(s::StokesParams{T}) where {T} = polarization(s)*inv(s.I + eps(T))
-fracpolarization(s::StokesParams{Complex{T}}) where {T} = polarization(s)*inv(s.I + eps(T))
+fracpolarization(s::StokesParams) = polarization(s)*inv(s.I)
 
 """
     mpol(m::StokesParameters{<:Real})
@@ -72,22 +71,22 @@ fracpolarization(s::StokesParams{Complex{T}}) where {T} = polarization(s)*inv(s.
 
 Compute the complex fractional linear polarization of a Stokes Parameter `m`
 """
-mpol(m::StokesParams{T}) where {T<:Real} = (m.Q + 1im*m.U)/(m.I + eps(T))
+mpol(m::StokesParams) = (m.Q + 1im*m.U)/m.I
 
 """
     m̆(m::Union{StokesParameters{<:Complex}, CoherencyMatrix)
 
 Computes the complex fractional linear polarization of the complex or visibility quantities.
-Note that this function can also be called used [`mbreve`](@ref)
+Note that this function can also be called used [`mbreve`](@ref) or [`mpol`](@ref).
 """
-m̆(m::StokesParams{Complex{T}}) where {T} = (m.Q + 1im*m.U)/(m.I + eps(T))
+m̆(m::StokesParams) = mpol(m)
 
 
 """
     $(SIGNATURES)
 
 Computes the complex fractional linear polarization of the complex or visibility quantities.
-Note that this function can also be called used [`m̆`](@ref)
+Note that this function can also be called used [`m̆`](@ref) or [`mpol`](@ref).
 """
 mbreve(m::StokesParams) = m̆(m)
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -63,7 +63,7 @@ end
 
 Returns the (Q/I, U/I, V/I) fractional polarization vector as a 3-element static vector.
 """
-fracpolarization(s::StokesParams) = polarization(s)*inv(s.I)
+fracpolarization(s::StokesParams) = polarization(s) / s.I
 
 """
     mpol(m::StokesParameters{<:Real})
@@ -71,7 +71,7 @@ fracpolarization(s::StokesParams) = polarization(s)*inv(s.I)
 
 Compute the complex fractional linear polarization of a Stokes Parameter `m`
 """
-mpol(m::StokesParams) = (m.Q + 1im*m.U)/m.I
+mpol(m::StokesParams) = linearpol(m) / m.I
 
 """
     m̆(m::Union{StokesParameters{<:Complex}, CoherencyMatrix)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -79,7 +79,6 @@ mpol(m::StokesParams) = linearpol(m) / m.I
 Computes the complex fractional linear polarization of the complex or visibility quantities.
 Note that this function can also be called used [`mbreve`](@ref) or [`mpol`](@ref).
 """
-m̆(m::StokesParams) = mpol(m)
 @deprecate m̆(m::StokesParams) mpol(m)
 
 """

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -74,31 +74,14 @@ Compute the complex fractional linear polarization of a Stokes Parameter `m`
 mpol(m::StokesParams) = linearpol(m) / m.I
 
 """
-    m̆(m::Union{StokesParameters{<:Complex}, CoherencyMatrix)
-
-Computes the complex fractional linear polarization of the complex or visibility quantities.
-Note that this function can also be called used [`mbreve`](@ref) or [`mpol`](@ref).
-"""
-@deprecate m̆(m::StokesParams) mpol(m)
-
-"""
-    $(SIGNATURES)
-
-Computes the complex fractional linear polarization of the complex or visibility quantities.
-Note that this function can also be called used [`m̆`](@ref) or [`mpol`](@ref).
-"""
-@deprecate mbreve(m::StokesParams) mpol(m)
-
-"""
     evpa(m::Union{StokesParams, CoherencyMatrix})
 Compute the evpa of a stokes vect or cohereny matrix.
 """
-evpa(m::StokesParams) = 1/2*atan(m.U, m.Q)
-evpa(m::StokesParams{<:Complex}) = 1/2*angle(m.U/m.Q)
+evpa(m::StokesParams) = angle(linearpol(m))/2
 
 
 # Now define the functions for Coherency matrix
-for f in (:linearpol, :polarization, :fracpolarization, :m̆, :mbreve, :evpa)
+for f in (:linearpol, :polarization, :fracpolarization, :mpol, :evpa)
     @eval begin
         $(f)(c::CoherencyMatrix) = $(f)(StokesParams(c))
     end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -88,7 +88,7 @@ m̆(m::StokesParams) = mpol(m)
 Computes the complex fractional linear polarization of the complex or visibility quantities.
 Note that this function can also be called used [`m̆`](@ref) or [`mpol`](@ref).
 """
-mbreve(m::StokesParams) = m̆(m)
+@deprecate mbreve(m::StokesParams) mpol(m)
 
 """
     evpa(m::Union{StokesParams, CoherencyMatrix})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,7 +178,7 @@ using Test
         @test complex(fp[1], fp[2]) ≈ linearpol(slin)/slin.I
         @test fp[end] ≈ 0
 
-        @test fracpolarization(StokesParams(1e-20, 1e-20, 1e-21, 1e-22)) ≈ [1, 0.1, 0.01]
+        @test fracpolarization(StokesParams(1f-5, 1f-5, 1f-6, 1f-7)) ≈ [1, 0.1, 0.01]
 
         @testset "ellipse" begin
             p = polellipse(s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,6 +178,8 @@ using Test
         @test complex(fp[1], fp[2]) ≈ linearpol(slin)/slin.I
         @test fp[end] ≈ 0
 
+        @test fracpolarization(StokesParams(1e-20, 1e-20, 1e-21, 1e-22)) ≈ [1, 0.1, 0.01]
+
         @testset "ellipse" begin
             p = polellipse(s)
             @test p.a*p.b ≈ s.V^2/4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,14 +200,17 @@ using Test
             U = rand(ComplexF64) - 0.5
             V = rand(ComplexF64) - 0.5
             s = StokesParams(I, Q, U, V)
-            @test mbreve(s) == m̆(s)
             c = CoherencyMatrix{CirBasis, LinBasis}(s)
             @test linearpol(c) ≈ linearpol(s)
             @test polarization(c) ≈ polarization(s)
             @test fracpolarization(c) ≈ fracpolarization(s)
-            @test m̆(c) ≈ m̆(s)
-            @test mbreve(c) ≈ mbreve(s)
+            @test mpol(c) ≈ mpol(s)
             @test evpa(c) ≈ evpa(s)
+            
+            # test that EVPA gives consistent results for real and complex types
+            real_s = StokesParams(1.0, 1.0, 0.1, 0.01)
+            complex_s = StokesParams(complex(1.0), 1.0, 0.1, 0.01)
+            @test evpa(real_s) ≈ evpa(complex_s) atol=1e-10
         end
 
     end


### PR DESCRIPTION
Motivation:
- dividing by (I + eps(T)) can give wrong results, see the new test that fails without this PR
- support for types without eps(T), for example numbers with uncertainties from Uncertain.jl or Measurements.jl
